### PR TITLE
Fix chat message error when MoreCompany is not installed

### DIFF
--- a/TooManyEmotes/CompatibilityPatcher.cs
+++ b/TooManyEmotes/CompatibilityPatcher.cs
@@ -22,6 +22,7 @@ using System.Reflection;
 using Unity.Netcode;
 using MoreCompany.Cosmetics;
 using BepInEx.Bootstrap;
+using System.Runtime.CompilerServices;
 
 namespace TooManyEmotes.CompatibilityPatcher {
 
@@ -101,10 +102,16 @@ namespace TooManyEmotes.CompatibilityPatcher {
         [HarmonyPostfix]
         public static void ApplyPatch() {
 
-            if (!Chainloader.PluginInfos.ContainsKey("me.swipez.melonloader.morecompany"))
+            if (Chainloader.PluginInfos.ContainsKey("me.swipez.melonloader.morecompany"))
             {
-                return;
+                MoreCompanyPatch();
             }
+        }
+
+        // seperate method without inlining to avoid throwing errors on chat message
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void MoreCompanyPatch()
+        {
             CosmeticApplication val = UnityEngine.Object.FindObjectOfType<CosmeticApplication>();
             if (CosmeticRegistry.locallySelectedCosmetics.Count <= 0 || val.spawnedCosmetics.Count > 0)
             {


### PR DESCRIPTION
Right now, every chat message will lag the game if you don't have MoreCompany installed

```cs
[Error  : Unity Log] FileNotFoundException: Could not load file or assembly 'MoreCompany, Version=1.7.2.0, Culture=neutral, PublicKeyToken=null' or one of its dependencies.
Stack trace:
(wrapper dynamic-method) HUDManager.DMD<HUDManager::AddPlayerChatMessageClientRpc>(HUDManager,string,int)
HUDManager.__rpc_handler_168728662 (Unity.Netcode.NetworkBehaviour target, Unity.Netcode.FastBufferReader reader, Unity.Netcode.__RpcParams rpcParams) (at <44743d9474784365a095189c76175301>:IL_0073)
```

This should fix the error by moving the morecompany compatibility patch to a separate method without inlining 

This way it won't attempt to load the types/assembly unless it's 100% installed