### PR TITLE
Enable dmcaFreeMode by default

### DIFF
--- a/TooManyEmotes/Audio/AudioManager.cs
+++ b/TooManyEmotes/Audio/AudioManager.cs
@@ -31,7 +31,7 @@ namespace TooManyEmotes.Audio
 
         public static bool muteEmoteAudio = false;
         public static bool emoteOnlyMode = false;
-        public static bool dmcaFreeMode = false;
+        public static bool dmcaFreeMode = true;
         public static float emoteVolumeMultiplier = 1;
 
 
@@ -85,7 +85,7 @@ namespace TooManyEmotes.Audio
                 emoteVolumeMultiplier = ES3.Load("TooManyEmotes.EmoteAudioVolume", SaveManager.TooManyEmotesSaveFileName, 1.0f);
                 muteEmoteAudio = ES3.Load("TooManyEmotes.MuteEmoteAudio", SaveManager.TooManyEmotesSaveFileName, false);
                 emoteOnlyMode = ES3.Load("TooManyEmotes.EmoteOnlyMode", SaveManager.TooManyEmotesSaveFileName, false);
-                dmcaFreeMode = ES3.Load("TooManyEmotes.DmcaFreeMode", SaveManager.TooManyEmotesSaveFileName, false);
+                dmcaFreeMode = ES3.Load("TooManyEmotes.DmcaFreeMode", SaveManager.TooManyEmotesSaveFileName, true);
             }
             catch (Exception e)
             {
@@ -93,7 +93,7 @@ namespace TooManyEmotes.Audio
                 emoteVolumeMultiplier = 1;
                 muteEmoteAudio = false;
                 emoteOnlyMode = false;
-                dmcaFreeMode = false;
+                dmcaFreeMode = true;
                 try
                 {
                     ES3.DeleteKey("TooManyEmotes.EmoteAudioVolume", SaveManager.TooManyEmotesSaveFileName);


### PR DESCRIPTION
This change allows streaming users who distribute mod packs via Thunderstore (or other means) to not require users to configure DMCA-free mode; they can simply join the game and start playing.