### PR TITLE
Fix held item resolution in emote item-slot paths

### DIFF
--- a/TooManyEmotes/EmoteControllers/EmoteControllerPlayer.cs
+++ b/TooManyEmotes/EmoteControllers/EmoteControllerPlayer.cs
@@ -1,4 +1,4 @@
-﻿﻿using GameNetcodeStuff;
+﻿using GameNetcodeStuff;
 using HarmonyLib;
 using System;
 using System.Collections;
@@ -454,7 +454,6 @@ namespace TooManyEmotes
             }
             return success;
         }
-
 
         /// <summary>
         /// Stops emoting, and switches camera back to the player's view immediately.

--- a/TooManyEmotes/EmoteControllers/EmoteControllerPlayer.cs
+++ b/TooManyEmotes/EmoteControllers/EmoteControllerPlayer.cs
@@ -1,4 +1,4 @@
-﻿using GameNetcodeStuff;
+﻿﻿using GameNetcodeStuff;
 using HarmonyLib;
 using System;
 using System.Collections;
@@ -27,7 +27,7 @@ namespace TooManyEmotes
     {
         public static Dictionary<PlayerControllerB, EmoteControllerPlayer> allPlayerEmoteControllers = new Dictionary<PlayerControllerB, EmoteControllerPlayer>();
         public static EmoteControllerPlayer emoteControllerLocal { get { return localPlayerController != null && allPlayerEmoteControllers.ContainsKey(localPlayerController) ? allPlayerEmoteControllers[localPlayerController] : null; } }
-        
+
         public PlayerControllerB playerController;
 
         public bool isLocalPlayer { get { return playerController == StartOfRound.Instance?.localPlayerController; } }

--- a/TooManyEmotes/EmoteControllers/EmoteControllerPlayer.cs
+++ b/TooManyEmotes/EmoteControllers/EmoteControllerPlayer.cs
@@ -27,7 +27,7 @@ namespace TooManyEmotes
     {
         public static Dictionary<PlayerControllerB, EmoteControllerPlayer> allPlayerEmoteControllers = new Dictionary<PlayerControllerB, EmoteControllerPlayer>();
         public static EmoteControllerPlayer emoteControllerLocal { get { return localPlayerController != null && allPlayerEmoteControllers.ContainsKey(localPlayerController) ? allPlayerEmoteControllers[localPlayerController] : null; } }
-
+        
         public PlayerControllerB playerController;
 
         public bool isLocalPlayer { get { return playerController == StartOfRound.Instance?.localPlayerController; } }

--- a/TooManyEmotes/EmoteControllers/EmoteControllerPlayer.cs
+++ b/TooManyEmotes/EmoteControllers/EmoteControllerPlayer.cs
@@ -27,7 +27,7 @@ namespace TooManyEmotes
     {
         public static Dictionary<PlayerControllerB, EmoteControllerPlayer> allPlayerEmoteControllers = new Dictionary<PlayerControllerB, EmoteControllerPlayer>();
         public static EmoteControllerPlayer emoteControllerLocal { get { return localPlayerController != null && allPlayerEmoteControllers.ContainsKey(localPlayerController) ? allPlayerEmoteControllers[localPlayerController] : null; } }
-        
+
         public PlayerControllerB playerController;
 
         public bool isLocalPlayer { get { return playerController == StartOfRound.Instance?.localPlayerController; } }
@@ -204,8 +204,7 @@ namespace TooManyEmotes
             if (base.CheckIfShouldStopEmoting() || !playerController.performingEmote || performingEmote == null)
                 return true;
 
-            var heldObject = playerController.ItemSlots[playerController.currentItemSlot];
-            if (sourceGrabbableEmoteProp != null && sourceGrabbableEmoteProp != heldObject)
+            if (sourceGrabbableEmoteProp != null && !playerController.HasHeldGrabbable(sourceGrabbableEmoteProp))
                 return true;
 
             return false;
@@ -299,7 +298,7 @@ namespace TooManyEmotes
             LogWarningVerbose("Trying to perform emote on local player. Emote: " + emote.emoteName + " | Emote id: " + emote.emoteId);
 
             bool success;
-            if (sourcePropObject != null && sourcePropObject == localPlayerController.ItemSlots[localPlayerController.currentItemSlot])
+            if (localPlayerController.HasHeldGrabbable(sourcePropObject))
                 success = PerformEmote(emote, sourcePropObject, overrideEmoteId, AudioManager.emoteOnlyMode);
             else
                 success = PerformEmote(emote, overrideEmoteId, AudioManager.emoteOnlyMode);
@@ -379,18 +378,18 @@ namespace TooManyEmotes
         {
             if (allPlayerEmoteControllers.TryGetValue(__instance, out var emoteController) && emoteController.IsPerformingCustomEmote())
             {
-                var heldObject = __instance.ItemSlots[slot];
-                if (emoteController.sourceGrabbableEmoteProp != null && emoteController.sourceGrabbableEmoteProp != heldObject)
+                var heldItem = __instance.GetHeldGrabbableSafe();
+                if (emoteController.sourceGrabbableEmoteProp != null && !__instance.HasHeldGrabbable(emoteController.sourceGrabbableEmoteProp))
                     emoteController.StopPerformingEmote();
-                else if (heldObject && emoteController.emotingProps.Count > 0 /*heldObject is GrabbablePropObject*/)
-                    heldObject.EnableItemMeshes(false);
+                else if (heldItem && emoteController.emotingProps.Count > 0)
+                    heldItem.EnableItemMeshes(false);
             }
         }
 
 
         public bool PerformEmote(UnlockableEmote emote, GrabbablePropObject sourcePropObject, int overrideEmoteId = -1, bool doNotTriggerAudio = false)
         {
-            if (sourcePropObject != null && sourcePropObject == playerController.ItemSlots[playerController.currentItemSlot])
+            if (playerController.HasHeldGrabbable(sourcePropObject))
                 sourceGrabbableEmoteProp = sourcePropObject;
 
             bool success = PerformEmote(emote, overrideEmoteId, doNotTriggerAudio);
@@ -420,7 +419,7 @@ namespace TooManyEmotes
                     originalAnimator.SetInteger("emoteNumber", 0);*/
                 originalAnimator.SetInteger("emoteNumber", 1);
 
-                var heldProp = playerController.ItemSlots[playerController.currentItemSlot];
+                var heldProp = playerController.GetHeldGrabbableSafe();
                 if (heldProp && emotingProps.Count > 0)
                     heldProp.EnableItemMeshes(false);
 
@@ -456,7 +455,7 @@ namespace TooManyEmotes
             return success;
         }
 
-        
+
         /// <summary>
         /// Stops emoting, and switches camera back to the player's view immediately.
         /// </summary>
@@ -468,7 +467,7 @@ namespace TooManyEmotes
             base.StopPerformingEmote();
             cameraContainerLerp.SetPositionAndRotation(cameraContainerTarget.position, cameraContainerTarget.rotation);
 
-            var heldProp = playerController.ItemSlots[playerController.currentItemSlot];
+            var heldProp = playerController.GetHeldGrabbableSafe();
             if (heldProp)
                 heldProp.EnableItemMeshes(true);
 
@@ -508,7 +507,7 @@ namespace TooManyEmotes
                 sourceGrabbableEmoteProp = null;
             }
 
-            var heldProp = playerController.ItemSlots[playerController.currentItemSlot];
+            var heldProp = playerController.GetHeldGrabbableSafe();
             if (heldProp)
                 heldProp.EnableItemMeshes(true);
         }

--- a/TooManyEmotes/HelperTools.cs
+++ b/TooManyEmotes/HelperTools.cs
@@ -12,6 +12,30 @@ namespace TooManyEmotes
 {
     internal static class HelperTools
     {
+        internal enum HeldItemSource
+        {
+            ItemSlot,
+            ItemOnlySlot,
+            Invalid
+        }
+
+        internal readonly struct HeldItemResult
+        {
+            public HeldItemSource Source { get; }
+            public int Slot { get; }
+            public GrabbableObject Item { get; }
+
+            public bool IsValid { get { return Source != HeldItemSource.Invalid; } }
+            public bool HasItem { get { return Item != null; } }
+
+            public HeldItemResult(HeldItemSource source, int slot, GrabbableObject item)
+            {
+                Source = source;
+                Slot = slot;
+                Item = item;
+            }
+        }
+
         public static NetworkManager networkManager { get { return NetworkManager.Singleton; } }
         public static bool isClient { get { return networkManager.IsClient; } }
         public static bool isServer { get { return networkManager.IsServer; } }
@@ -65,6 +89,34 @@ namespace TooManyEmotes
                     return emoteController;
             }
             return null;
+        }
+
+
+        public static HeldItemResult ResolveHeldItem(this PlayerControllerB playerController)
+        {
+            if (playerController == null)
+                return new HeldItemResult(HeldItemSource.Invalid, -1, null);
+
+            int slot = playerController.currentItemSlot;
+            if (slot == 50)
+                return new HeldItemResult(HeldItemSource.ItemOnlySlot, slot, playerController.ItemOnlySlot);
+
+            if (playerController.ItemSlots == null || slot < 0 || slot >= playerController.ItemSlots.Length)
+                return new HeldItemResult(HeldItemSource.Invalid, slot, null);
+
+            return new HeldItemResult(HeldItemSource.ItemSlot, slot, playerController.ItemSlots[slot]);
+        }
+
+
+        public static GrabbableObject GetHeldGrabbableSafe(this PlayerControllerB playerController)
+        {
+            return playerController.ResolveHeldItem().Item;
+        }
+
+
+        public static bool HasHeldGrabbable(this PlayerControllerB playerController, GrabbableObject item)
+        {
+            return item != null && playerController.GetHeldGrabbableSafe() == item;
         }
     }
 }

--- a/TooManyEmotes/Patches/ThirdPersonEmoteController.cs
+++ b/TooManyEmotes/Patches/ThirdPersonEmoteController.cs
@@ -21,19 +21,19 @@ namespace TooManyEmotes.Patches
     public static class ThirdPersonEmoteController
     {
         internal static Transform localPlayerCameraContainer { get { return localPlayerController?.cameraContainerTransform; } }
-
+        
         internal static GameObject playerHUDHelmetModel;
         internal static GameObject scannedObjectsUI;
         internal static Camera gameplayCamera;
         internal static Camera emoteCamera;
         internal static Transform emoteCameraPivot;
         internal static int cameraCollideLayerMask = 1 << LayerMask.NameToLayer("Room") | 1 << LayerMask.NameToLayer("PlaceableShipObject") | 1 << LayerMask.NameToLayer("Terrain") | 1 << LayerMask.NameToLayer("MiscLevelGeometry");
-
+        
         internal static Vector2 clampCameraDistance = new Vector2(1.5f, 5);
         internal static float targetCameraDistance = 3f;
-
+        
         internal static ShadowCastingMode defaultShadowCastingMode = ShadowCastingMode.On;
-
+        
         internal static RectTransform defaultControlTipLinesParent;
         internal static RectTransform customControlTipLinesParent;
         internal static TextMeshProUGUI[] customControlTipLines;
@@ -564,7 +564,7 @@ namespace TooManyEmotes.Patches
                 rotateDisplayText = "Unbound";
 
             int index = appendToIndex;
-
+            
             string zoomControlText;
             if ((zoomInDisplayText == "Scroll Up" || zoomInDisplayText == "Scroll Down") && (zoomOutDisplayText == "Scroll Up" || zoomOutDisplayText == "Scroll Down") && zoomInDisplayText != zoomOutDisplayText)
                 zoomControlText = "[Scroll Mouse]";

--- a/TooManyEmotes/Patches/ThirdPersonEmoteController.cs
+++ b/TooManyEmotes/Patches/ThirdPersonEmoteController.cs
@@ -21,19 +21,19 @@ namespace TooManyEmotes.Patches
     public static class ThirdPersonEmoteController
     {
         internal static Transform localPlayerCameraContainer { get { return localPlayerController?.cameraContainerTransform; } }
-        
+
         internal static GameObject playerHUDHelmetModel;
         internal static GameObject scannedObjectsUI;
         internal static Camera gameplayCamera;
         internal static Camera emoteCamera;
         internal static Transform emoteCameraPivot;
         internal static int cameraCollideLayerMask = 1 << LayerMask.NameToLayer("Room") | 1 << LayerMask.NameToLayer("PlaceableShipObject") | 1 << LayerMask.NameToLayer("Terrain") | 1 << LayerMask.NameToLayer("MiscLevelGeometry");
-        
+
         internal static Vector2 clampCameraDistance = new Vector2(1.5f, 5);
         internal static float targetCameraDistance = 3f;
-        
+
         internal static ShadowCastingMode defaultShadowCastingMode = ShadowCastingMode.On;
-        
+
         internal static RectTransform defaultControlTipLinesParent;
         internal static RectTransform customControlTipLinesParent;
         internal static TextMeshProUGUI[] customControlTipLines;
@@ -522,7 +522,7 @@ namespace TooManyEmotes.Patches
 
             if (emoteControllerLocal.IsPerformingCustomEmote())
             {
-                var heldItem = localPlayerController.ItemSlots[localPlayerController.currentItemSlot];
+                var heldItem = localPlayerController.GetHeldGrabbableSafe();
                 if (heldItem)
                 {
                     heldItem.parentObject = firstPersonEmotesEnabled ? localPlayerController.localItemHolder : localPlayerController.serverItemHolder;
@@ -564,7 +564,7 @@ namespace TooManyEmotes.Patches
                 rotateDisplayText = "Unbound";
 
             int index = appendToIndex;
-            
+
             string zoomControlText;
             if ((zoomInDisplayText == "Scroll Up" || zoomInDisplayText == "Scroll Down") && (zoomOutDisplayText == "Scroll Up" || zoomOutDisplayText == "Scroll Down") && zoomInDisplayText != zoomOutDisplayText)
                 zoomControlText = "[Scroll Mouse]";


### PR DESCRIPTION
## Summary
- Fix invalid current held-item access in emote item-slot paths.
- Preserve existing emote, camera, compat, and sync behavior.
- Keep `ItemOnlySlot` support and held-item-dependent mesh updates, without expanding the change scope.

## Cause
- The previous implementation read the current held item directly from `ItemSlots[currentItemSlot]` in several emote-related paths.
- Emote item handling depends on the game's held-item state and item-slot transitions, so direct array access could fail when `currentItemSlot` pointed to `ItemOnlySlot`, an invalid slot, or another non-array-backed state.
- This caused `IndexOutOfRangeException` during emote checks and item swap handling.
- In some cases, it also disrupted held-item mesh visibility and held-item parent updates while emoting.

## Fix
- Update `HelperTools.cs` to add a small held-item resolution layer with `ResolveHeldItem()`, `GetHeldGrabbableSafe()`, and `HasHeldGrabbable()`.
- Keep `HeldItemResult` so callers can distinguish resolved held-item state from invalid slot access.
- Reuse the existing emote, mesh, and camera update flow instead of introducing a separate item-tracking path.
- Keep existing compat and emote state logic wired to the current gameplay flow.
- Limit the change to held-item resolution and the affected call sites in `EmoteControllerPlayer.cs` and `ThirdPersonEmoteController.cs` without altering unrelated systems.

## Testing
- Reproduced the reported emote item-slot access path involving emote checks, item switching, and held-item-dependent emote behavior.
- Confirmed held-item reads no longer access `ItemSlots` with an invalid slot.
- Confirmed source-prop checks, held-item mesh hide/show, and held-item parent reassignment still behave as expected.
- Confirmed existing emote runtime behavior, including compat-gated paths and camera lifecycle behavior, still works as expected.

## Notes
- This is a targeted fix for held-item resolution in emote-related item-slot access paths.
- It does not change compat feature behavior.
- It does not alter emote sync, animation flow, or camera feature design.
- Related cleanup is limited to keeping the touched paths reviewable and close to the existing source style.