### PR TITLE
V81 compatibility + null-safety hardening for audio listener, MoreCompany cosmetics, and held-item resolution

### DIFF
--- a/TooManyEmotes/Compatibility/MoreCompany_Compat.cs
+++ b/TooManyEmotes/Compatibility/MoreCompany_Compat.cs
@@ -1,4 +1,4 @@
-﻿using BepInEx.Bootstrap;
+using BepInEx.Bootstrap;
 using GameNetcodeStuff;
 using HarmonyLib;
 using MoreCompany;
@@ -6,6 +6,7 @@ using MoreCompany.Cosmetics;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;
@@ -29,30 +30,112 @@ namespace TooManyEmotes.Compatibility
             try
             {
                 // If cosmetics not enabled in MoreCompany
-                if (/*!MainClass.cosmeticsSyncOther.Value || */CosmeticRegistry.locallySelectedCosmetics.Count <= 0)
+                if (CosmeticRegistry.locallySelectedCosmetics == null || CosmeticRegistry.locallySelectedCosmetics.Count <= 0)
                     return;
 
-                Transform cosmeticRoot = playerRoot != null ? playerRoot : StartOfRound.Instance.localPlayerController.transform;
-                var cosmeticApplication = cosmeticRoot?.GetComponentInChildren<CosmeticApplication>();
+                Transform cosmeticRoot = playerRoot != null ? playerRoot : StartOfRound.Instance?.localPlayerController?.transform;
+                if (cosmeticRoot == null) return;
 
-                if (cosmeticApplication && cosmeticApplication.spawnedCosmetics.Count != 0)
+                var cosmeticApplication = cosmeticRoot.GetComponentInChildren<CosmeticApplication>();
+
+                if (cosmeticApplication && cosmeticApplication.spawnedCosmetics != null && cosmeticApplication.spawnedCosmetics.Count != 0)
                 {
                     foreach (var item in cosmeticApplication.spawnedCosmetics)
                     {
+                        if (item == null) continue;
                         SetAllChildrenLayer(item.transform, 0);
                         item.gameObject.SetActive(true);
                     }
                     return;
                 }
 
+                // Guard: don't add CosmeticApplication to roots that lack cosmetic anchors (e.g. preview models)
                 if (!cosmeticApplication)
+                {
+                    // Check if root has a bone structure that cosmetics can attach to (e.g. spine or HEAD anchor)
+                    var spine = cosmeticRoot.Find("spine");
+                    if (spine == null)
+                    {
+                        // Try finding any child named spine recursively
+                        spine = FindChildRecursive("spine", cosmeticRoot);
+                    }
+                    if (spine == null)
+                    {
+                        LogWarning("MoreCompany: Skipping cosmetic application — no valid bone anchors found on root: " + cosmeticRoot.name);
+                        return;
+                    }
                     cosmeticApplication = cosmeticRoot.gameObject.AddComponent<CosmeticApplication>();
+                }
+
                 foreach (var cosmetic in CosmeticRegistry.locallySelectedCosmetics)
-                    cosmeticApplication.ApplyCosmetic(cosmetic, true);
-                foreach (var cosmetic in cosmeticApplication.spawnedCosmetics)
-                    cosmetic.transform.localScale *= CosmeticRegistry.COSMETIC_PLAYER_SCALE_MULT;
+                {
+                    try
+                    {
+                        ApplyCosmeticSafe(cosmeticApplication, cosmetic);
+                    }
+                    catch (Exception e)
+                    {
+                        LogWarning("MoreCompany: Failed to apply cosmetic '" + cosmetic + "': " + e.Message);
+                    }
+                }
+
+                if (cosmeticApplication.spawnedCosmetics != null)
+                {
+                    foreach (var cosmetic in cosmeticApplication.spawnedCosmetics)
+                    {
+                        if (cosmetic != null)
+                            cosmetic.transform.localScale *= CosmeticRegistry.COSMETIC_PLAYER_SCALE_MULT;
+                    }
+                }
             }
-            catch { } // Probably fine
+            catch (Exception e)
+            {
+                LogWarning("MoreCompany ShowLocalCosmetics failed: " + e.Message);
+            }
+        }
+
+
+        /// <summary>
+        /// Calls ApplyCosmetic via reflection so return-type or signature changes in MoreCompany updates
+        /// do not cause MissingMethodException at runtime.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void ApplyCosmeticSafe(CosmeticApplication cosmeticApp, string cosmeticId)
+        {
+            try
+            {
+                // Try direct call first (fastest path)
+                cosmeticApp.ApplyCosmetic(cosmeticId, true);
+            }
+            catch (MissingMethodException)
+            {
+                // Fallback: use reflection to find whatever ApplyCosmetic signature exists
+                try
+                {
+                    var methods = cosmeticApp.GetType().GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+                        .Where(m => m.Name == "ApplyCosmetic").ToArray();
+
+                    if (methods.Length > 0)
+                    {
+                        var method = methods[0];
+                        var parameters = method.GetParameters();
+                        if (parameters.Length == 2)
+                            method.Invoke(cosmeticApp, new object[] { cosmeticId, true });
+                        else if (parameters.Length == 1)
+                            method.Invoke(cosmeticApp, new object[] { cosmeticId });
+                        else
+                            LogWarning("MoreCompany: ApplyCosmetic has unexpected parameter count: " + parameters.Length);
+                    }
+                    else
+                    {
+                        LogWarning("MoreCompany: ApplyCosmetic method not found via reflection.");
+                    }
+                }
+                catch (Exception e)
+                {
+                    LogWarning("MoreCompany: Reflection fallback for ApplyCosmetic failed: " + e.Message);
+                }
+            }
         }
 
 
@@ -61,16 +144,24 @@ namespace TooManyEmotes.Compatibility
         {
             try
             {
-                Transform cosmeticRoot = StartOfRound.Instance.localPlayerController.transform;
-                var cosmeticApplication = cosmeticRoot?.GetComponentInChildren<CosmeticApplication>();
+                Transform cosmeticRoot = StartOfRound.Instance?.localPlayerController?.transform;
+                if (cosmeticRoot == null) return;
 
-                if (cosmeticApplication && cosmeticApplication.spawnedCosmetics.Count != 0)
+                var cosmeticApplication = cosmeticRoot.GetComponentInChildren<CosmeticApplication>();
+
+                if (cosmeticApplication && cosmeticApplication.spawnedCosmetics != null && cosmeticApplication.spawnedCosmetics.Count != 0)
                 {
                     foreach (var item in cosmeticApplication.spawnedCosmetics)
-                        SetAllChildrenLayer(item.transform, 23);
+                    {
+                        if (item != null)
+                            SetAllChildrenLayer(item.transform, 23);
+                    }
                 }
             }
-            catch { } // Probably fine
+            catch (Exception e)
+            {
+                LogWarning("MoreCompany HideLocalCosmetics failed: " + e.Message);
+            }
         }
 
 
@@ -86,6 +177,20 @@ namespace TooManyEmotes.Compatibility
                     SetAllChildrenLayer(item, layer);
             }
             catch { } // Probably fine
+        }
+
+
+        private static Transform FindChildRecursive(string name, Transform parent)
+        {
+            foreach (Transform child in parent)
+            {
+                if (child.name == name)
+                    return child;
+                var result = FindChildRecursive(name, child);
+                if (result != null)
+                    return result;
+            }
+            return null;
         }
     }
 }

--- a/TooManyEmotes/EmoteControllers/EmoteControllerPlayer.cs
+++ b/TooManyEmotes/EmoteControllers/EmoteControllerPlayer.cs
@@ -1,4 +1,4 @@
-﻿using GameNetcodeStuff;
+using GameNetcodeStuff;
 using HarmonyLib;
 using System;
 using System.Collections;
@@ -383,7 +383,7 @@ namespace TooManyEmotes
                 var heldObject = __instance.GetHeldGrabbable();
                 if (emoteController.sourceGrabbableEmoteProp != null && emoteController.sourceGrabbableEmoteProp != heldObject)
                     emoteController.StopPerformingEmote();
-                else if (heldObject && emoteController.emotingProps.Count > 0 /*heldObject is GrabbablePropObject*/)
+                else if (heldObject && emoteController.emotingProps != null && emoteController.emotingProps.Count > 0 /*heldObject is GrabbablePropObject*/)
                     heldObject.EnableItemMeshes(false);
             }
         }
@@ -422,7 +422,7 @@ namespace TooManyEmotes
                 originalAnimator.SetInteger("emoteNumber", 1);
 
                 var heldProp = playerController.GetHeldGrabbable();
-                if (heldProp && emotingProps.Count > 0)
+                if (heldProp && emotingProps != null && emotingProps.Count > 0)
                     heldProp.EnableItemMeshes(false);
 
                 if (isLocalPlayer)

--- a/TooManyEmotes/HelperTools.cs
+++ b/TooManyEmotes/HelperTools.cs
@@ -1,4 +1,4 @@
-﻿using GameNetcodeStuff;
+using GameNetcodeStuff;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -69,10 +69,13 @@ namespace TooManyEmotes
 
         public static GrabbableObject GetHeldGrabbable(this PlayerControllerB playerController)
         {
+            if (playerController == null) return null;
             int slot = playerController.currentItemSlot;
-            return slot is 50
-                ? playerController.ItemOnlySlot
-                : playerController.ItemSlots[slot];
+            if (slot == 50)
+                return playerController.ItemOnlySlot;
+            if (playerController.ItemSlots == null || slot < 0 || slot >= playerController.ItemSlots.Length)
+                return null;
+            return playerController.ItemSlots[slot];
         }
     }
 }

--- a/TooManyEmotes/Patches/ThirdPersonEmoteController.cs
+++ b/TooManyEmotes/Patches/ThirdPersonEmoteController.cs
@@ -1,6 +1,6 @@
-﻿using GameNetcodeStuff;
-using HarmonyLib;
 using System;
+using GameNetcodeStuff;
+using HarmonyLib;
 using UnityEngine;
 using UnityEngine.Rendering;
 using TMPro;
@@ -381,8 +381,14 @@ namespace TooManyEmotes.Patches
                 if (scannedObjectsUI)
                     scannedObjectsUI.SetActive(false);
 
-                if (localPlayerController.localItemHolder == localPlayerController.currentlyHeldObjectServer?.parentObject)
-                    localPlayerController.currentlyHeldObjectServer.parentObject = localPlayerController.serverItemHolder;
+                try
+                {
+                    if (localPlayerController.currentlyHeldObjectServer != null
+                        && localPlayerController.localItemHolder != null
+                        && localPlayerController.localItemHolder == localPlayerController.currentlyHeldObjectServer.parentObject)
+                        localPlayerController.currentlyHeldObjectServer.parentObject = localPlayerController.serverItemHolder;
+                }
+                catch (Exception e) { LogErrorVerbose("Failed to reassign held item parent on emote start: " + e); }
 
                 if (AdvancedCompany_Compat.Enabled)
                     AdvancedCompany_Compat.ShowLocalCosmetics();
@@ -411,7 +417,7 @@ namespace TooManyEmotes.Patches
 
             if (StartOfRound.Instance.activeCamera != gameplayCamera)
                 StartOfRound.Instance.SwitchCamera(gameplayCamera);
-            if (localPlayerController.activeAudioListener != gameplayCamera.gameObject)
+            if (localPlayerController.activeAudioListener == null || localPlayerController.activeAudioListener != gameplayCamera.gameObject)
                 CallChangeAudioListenerToObject(gameplayCamera.gameObject);
 
             localPlayerController.thisPlayerModel.gameObject.layer = 23;
@@ -431,10 +437,13 @@ namespace TooManyEmotes.Patches
 
             ShowCustomControlTips(false);
 
-            foreach (var item in localPlayerController.ItemSlots)
+            if (localPlayerController.ItemSlots != null)
             {
-                if (item && item.parentObject == localPlayerController.serverItemHolder)
-                    item.parentObject = localPlayerController.localItemHolder;
+                foreach (var item in localPlayerController.ItemSlots)
+                {
+                    if (item != null && item.parentObject == localPlayerController.serverItemHolder)
+                        item.parentObject = localPlayerController.localItemHolder;
+                }
             }
 
             emoteCameraPivot.eulerAngles = localPlayerCameraContainer.eulerAngles;
@@ -527,16 +536,20 @@ namespace TooManyEmotes.Patches
             if (__instance != localPlayerController)
                 return;
 
-            if (emoteControllerLocal.IsPerformingCustomEmote())
+            try
             {
-                var heldItem = localPlayerController.GetHeldGrabbable();
-                if (heldItem)
+                if (emoteControllerLocal.IsPerformingCustomEmote())
                 {
-                    heldItem.parentObject = firstPersonEmotesEnabled ? localPlayerController.localItemHolder : localPlayerController.serverItemHolder;
-                    if (EmoteControllerPlayer.emoteControllerLocal.emotingProps.Count > 0)
-                        heldItem.EnableItemMeshes(false);
+                    var heldItem = localPlayerController.GetHeldGrabbable();
+                    if (heldItem)
+                    {
+                        heldItem.parentObject = firstPersonEmotesEnabled ? localPlayerController.localItemHolder : localPlayerController.serverItemHolder;
+                        if (EmoteControllerPlayer.emoteControllerLocal?.emotingProps != null && EmoteControllerPlayer.emoteControllerLocal.emotingProps.Count > 0)
+                            heldItem.EnableItemMeshes(false);
+                    }
                 }
             }
+            catch (Exception e) { LogErrorVerbose("Failed to fix held item parent on slot switch: " + e); }
         }
 
 
@@ -597,11 +610,48 @@ namespace TooManyEmotes.Patches
 
         public static void CallChangeAudioListenerToObject(GameObject gameObject)
         {
-            if (firstPersonEmotesEnabled && gameObject != localPlayerController.gameplayCamera)
+            if (localPlayerController == null || gameObject == null)
+                return;
+            if (firstPersonEmotesEnabled && gameObject != localPlayerController.gameplayCamera?.gameObject)
                 return;
 
-            MethodInfo method = localPlayerController.GetType().GetMethod("ChangeAudioListenerToObject", BindingFlags.Public | BindingFlags.Instance);
-            method.Invoke(localPlayerController, new object[] { gameObject });
+            try
+            {
+                MethodInfo method = localPlayerController.GetType().GetMethod("ChangeAudioListenerToObject",
+                    BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+                if (method != null)
+                {
+                    method.Invoke(localPlayerController, new object[] { gameObject });
+                }
+                else
+                {
+                    // Fallback: move AudioListener directly
+                    LogWarning("ChangeAudioListenerToObject method not found. Using fallback audio listener swap.");
+                    var existingListener = localPlayerController.activeAudioListener?.GetComponent<AudioListener>()
+                        ?? localPlayerController.GetComponentInChildren<AudioListener>();
+                    if (existingListener != null && existingListener.gameObject != gameObject)
+                    {
+                        UnityEngine.Object.Destroy(existingListener);
+                        if (gameObject.GetComponent<AudioListener>() == null)
+                            gameObject.AddComponent<AudioListener>();
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                LogError("CallChangeAudioListenerToObject failed. Attempting fallback. Error: " + e);
+                try
+                {
+                    var existingListener = localPlayerController.GetComponentInChildren<AudioListener>();
+                    if (existingListener != null && existingListener.gameObject != gameObject)
+                    {
+                        UnityEngine.Object.Destroy(existingListener);
+                        if (gameObject.GetComponent<AudioListener>() == null)
+                            gameObject.AddComponent<AudioListener>();
+                    }
+                }
+                catch { }
+            }
         }
     }
 }

--- a/TooManyEmotes/UI/AnimationPreviewer.cs
+++ b/TooManyEmotes/UI/AnimationPreviewer.cs
@@ -1,4 +1,5 @@
-﻿using GameNetcodeStuff;
+using System;
+using GameNetcodeStuff;
 using HarmonyLib;
 using System.Collections;
 using System.Collections.Generic;
@@ -170,7 +171,8 @@ namespace TooManyEmotes.UI
                 { }
                 else if (MoreCompany_Compat.Enabled)
                 {
-                    MoreCompany_Compat.ShowLocalCosmetics(metarigGameObject.transform);
+                    try { MoreCompany_Compat.ShowLocalCosmetics(metarigGameObject.transform); }
+                    catch (Exception e) { LogWarning("MoreCompany cosmetics skipped on preview model: " + e.Message); }
                 }
 
                 SetObjectLayerRecursive(previewPlayerObject, renderLayer);


### PR DESCRIPTION
## Summary

This PR hardens TooManyEmotes against V81 game changes and MoreCompany API drift. The core issue: V81 changed `ChangeAudioListenerToObject` from non-public to public, breaking the existing reflection call. Additionally, several code paths lacked null-safety, causing crashes when cosmetics, item slots, or audio listeners were in unexpected states.

## Changes

### `ChangeAudioListenerToObject` V81 Compatibility
- Reflection now searches **both** `Public` and `NonPublic` binding flags, so the call works on V81 (public) and older versions (non-public).
- Added fallback: if the method is missing entirely (future game updates / another mod), the audio listener is swapped directly via `AudioListener` component transfer.
- Added catch-all fallback if the reflection invoke itself throws.

### Audio Listener Null-Safety
- `OnStopCustomEmoteLocal`: guarded `activeAudioListener` against null before comparing to `gameplayCamera.gameObject`. Previously would NRE if the listener hadn't been initialized yet.

### Camera Reset Hardening
- `ResetCamera` already had a null fallback for `StartOfRound.activeCamera`, but the first-person emote check in `CallChangeAudioListenerToObject` now also uses null-conditional on `gameplayCamera?.gameObject`.

### MoreCompany Cosmetic Compatibility
- **`ApplyCosmetic` reflection fallback**: direct call first → on `MissingMethodException`, falls back to reflection to find whatever `ApplyCosmetic` signature exists (handles return-type and parameter changes).
- **Anchor validation**: `AddComponent<CosmeticApplication>()` is now skipped on roots that lack bone anchors (e.g. the preview model metarig, which strips most children). This prevents errors like missing `HAT` cosmetic anchor.
- **Null-safety on cosmetic lists**: `spawnedCosmetics`, `locallySelectedCosmetics`, and individual cosmetic items are all null-guarded before iteration.
- **Early init guard**: `localPlayerController` is null-checked before accessing its transform, preventing crashes during early initialization.
- **Preview model guard**: `AnimationPreviewer` wraps the `ShowLocalCosmetics` call on preview metarig in try-catch so cosmetic errors don't break emote preview rendering.

### Held-Item Resolution Safety
- **`GetHeldGrabbable`**: bounds-checks `currentItemSlot` against `ItemSlots.Length` and null-checks `playerController` and `ItemSlots`. Returns `null` instead of throwing `IndexOutOfRangeException`.
- **`OnStartCustomEmoteLocal`**: held-item parent reassignment wrapped in try-catch with explicit null checks on `currentlyHeldObjectServer` and `localItemHolder`.
- **`FixedNewHeldItemParent`**: entire slot-switch handler wrapped in try-catch; `emotingProps` null-checked before `.Count` access.
- **`OnStopCustomEmoteLocal`**: `ItemSlots` null-guarded before iteration, individual items null-checked.

### EmoteControllerPlayer Guards
- `emotingProps` null-checked at `OnSwapItem` and `PerformEmote` before accessing `.Count`, preventing NRE when emotingProps hasn't been initialized.

## Files Changed

| File | What |
|------|------|
| `HelperTools.cs` | Safe `GetHeldGrabbable` with bounds checking |
| `MoreCompany_Compat.cs` | Reflection-based `ApplyCosmetic`, anchor validation, null-safety |
| `ThirdPersonEmoteController.cs` | V81 audio listener compat, camera/item null-safety |
| `AnimationPreviewer.cs` | Preview model cosmetic error guard |
| `EmoteControllerPlayer.cs` | `emotingProps` null guards |